### PR TITLE
Handle JSON decode errors in Ollama client

### DIFF
--- a/ollama_client.py
+++ b/ollama_client.py
@@ -30,7 +30,11 @@ class OllamaClient:
                 response.raise_for_status()
                 
                 result = response.json()
-                return json.loads(result["response"])
+                try:
+                    return json.loads(result["response"])
+                except json.JSONDecodeError as e:
+                    logger.error(f"Некорректный JSON в ответе модели: {result.get('response')}")
+                    raise ValueError("Модель вернула некорректный JSON") from e
                 
         except Exception as e:
             logger.error(f"Ошибка генерации с моделью {model}: {e}")


### PR DESCRIPTION
## Summary
- handle JSON decode errors in `OllamaClient.generate_structured`

## Testing
- `python -m py_compile ollama_client.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba0e65b94c832191fb19824b9600ee
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds error handling for JSON decode errors in `generate_structured` method of `OllamaClient`, logging errors and raising `ValueError`.
> 
>   - **Behavior**:
>     - Adds error handling for JSON decode errors in `generate_structured` method of `OllamaClient`.
>     - Logs error message if JSON is invalid and raises `ValueError`.
>   - **Testing**:
>     - Verified with `python -m py_compile ollama_client.py`.
>     - Tested using `pytest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hxrz11%2Fsgr-test2&utm_source=github&utm_medium=referral)<sup> for 1112d79be9a52752f7386941473ce0ecda3dfa5b. You can [customize](https://app.ellipsis.dev/hxrz11/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->