### PR TITLE
Fix table case and remove limit instruction

### DIFF
--- a/database.py
+++ b/database.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Any
 
 import asyncpg
 import dotenv
+import re
 
 dotenv.load_dotenv()
 
@@ -53,6 +54,10 @@ class DatabaseManager:
         # Обязательное указание таблицы
         if 'purchaseallview' not in sql_lower:
             raise ValueError("Запросы должны использовать таблицу PurchaseAllView")
+
+        # Корректное написание названия таблицы
+        if '"purchaseallview"' not in sql_lower:
+            sql = re.sub(r'(?i)purchaseallview', '"PurchaseAllView"', sql)
         
         # Добавление LIMIT если отсутствует
         if 'limit' not in sql_lower:

--- a/main.py
+++ b/main.py
@@ -98,7 +98,6 @@ async def process_query(request: QueryRequest):
 - Все названия полей в двойных кавычках
 - Для текстового поиска используй ILIKE '%term%'
 - Для номенклатуры ищи по двум полям: ("Nomenclature" ILIKE '%term%' OR "NomenclatureFullName" ILIKE '%term%')
-- Добавь LIMIT 50 если не указано иначе
 """
 
         # Получение схемы для структурированного вывода

--- a/sgr_schema.py
+++ b/sgr_schema.py
@@ -30,7 +30,7 @@ class SQLGeneration(BaseModel):
 
 # Схема базы данных для промптов
 DATABASE_SCHEMA = """
-Таблица: PurchaseAllView (PostgreSQL)
+Таблица: "PurchaseAllView" (PostgreSQL)
 
 Поля:
 - "GlobalUid" (text) - Уникальный идентификатор записи
@@ -60,7 +60,7 @@ DATABASE_SCHEMA = """
 ВАЖНЫЕ ПРАВИЛА:
 1. Используй ILIKE '%term%' для нечеткого поиска
 2. Для поиска по номенклатуре ищи по обоим полям: ("Nomenclature" ILIKE '%term%' OR "NomenclatureFullName" ILIKE '%term%')
-3. Все названия полей в двойных кавычках
+3. Все названия полей и таблицы в двойных кавычках
 4. Даты в формате YYYY-MM-DD
 5. Для поиска пользователей используй "UserName" или "PurchaseCardUserFio"
 """


### PR DESCRIPTION
## Summary
- Enforce proper quoting of the PurchaseAllView table before executing SQL queries.
- Remove LIMIT 50 instruction from the model prompt.
- Document that both field and table names must be double-quoted.

## Testing
- `python -m py_compile main.py database.py sgr_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba929d1588832185f1d2416649b5d1
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforce quoting of `PurchaseAllView` table in SQL queries and remove `LIMIT 50` from prompts, updating documentation accordingly.
> 
>   - **Behavior**:
>     - Enforce quoting of `PurchaseAllView` table in `execute_query()` in `database.py` using regex substitution.
>     - Remove `LIMIT 50` instruction from the SQL prompt in `process_query()` in `main.py`.
>   - **Documentation**:
>     - Update `DATABASE_SCHEMA` in `sgr_schema.py` to document that both field and table names must be double-quoted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hxrz11%2Fsgr-test2&utm_source=github&utm_medium=referral)<sup> for 9380123ae8c32c7319ea0a2d26b8faa0d0634b0a. You can [customize](https://app.ellipsis.dev/hxrz11/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->