### PR TITLE
Normalize SQL search terms and numeric fields

### DIFF
--- a/sgr_schema.py
+++ b/sgr_schema.py
@@ -58,7 +58,7 @@ DATABASE_SCHEMA = """
 - "PurchaseCardUserFio" (text) - ФИО пользователя
 
 ВАЖНЫЕ ПРАВИЛА:
-1. Используй ILIKE '%term%' для нечеткого поиска
+1. Используй ILIKE '%term%' для нечеткого поиска (используй основу слова, например '%ламп%')
 2. Для поиска по номенклатуре ищи по обоим полям: ("Nomenclature" ILIKE '%term%' OR "NomenclatureFullName" ILIKE '%term%')
 3. Все названия полей и таблицы в двойных кавычках
 4. Даты в формате YYYY-MM-DD
@@ -67,7 +67,7 @@ DATABASE_SCHEMA = """
 
 EXAMPLE_QUERIES = [
     "Найди закупки по 105 заявке → WHERE \"OrderNumber\" ILIKE '%105%'",
-    "Найди номенклатуры с лампами → WHERE (\"Nomenclature\" ILIKE '%лампа%' OR \"NomenclatureFullName\" ILIKE '%лампа%')",
+    "Найди номенклатуры с лампами → WHERE (\"Nomenclature\" ILIKE '%ламп%' OR \"NomenclatureFullName\" ILIKE '%ламп%')",
     "Сколько позиций у Петрова в работе → WHERE (\"UserName\" ILIKE '%Petrov%' OR \"PurchaseCardUserName\" ILIKE '%Petrov%' OR \"PurchaseCardUserFio\" ILIKE '%Petrov%') AND \"RemainingQuantity\" > 0",
     "Покажи заявки по объекту Газопровод → WHERE \"ObjectName\" ILIKE '%Газопровод%'"
 ]


### PR DESCRIPTION
## Summary
- normalize SQL queries by trimming Russian word endings and casting numeric fields to numeric before execution
- update prompt rules and examples to encourage using word stems (e.g. '%ламп%')

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baaa8f12208321b66efa9a19ac7668
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Normalize SQL queries by trimming Russian word endings and casting numeric fields, and update prompt rules to use word stems.
> 
>   - **Behavior**:
>     - Normalize SQL queries by trimming Russian word endings and casting numeric fields to numeric in `execute_query()` in `database.py`.
>     - Update `_normalize_query()` in `database.py` to handle Russian word endings and numeric field casting.
>   - **Prompt Rules**:
>     - Update prompt rules in `sgr_schema.py` to encourage using word stems (e.g., '%ламп%').
>     - Modify example queries in `sgr_schema.py` to reflect new prompt rules.
>   - **Testing**:
>     - Ensure functionality with `pytest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hxrz11%2Fsgr-test2&utm_source=github&utm_medium=referral)<sup> for 9615556806f9d5da43cd599ffde019768d1f5ff1. You can [customize](https://app.ellipsis.dev/hxrz11/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->