### PR TITLE
fix: show executed SQL query

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,7 +1,7 @@
 import os
 import time
 import logging
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
 import asyncpg
 import dotenv
@@ -40,8 +40,11 @@ class DatabaseManager:
             logger.error(f"Ошибка подключения к БД: {e}")
             raise
     
-    async def execute_query(self, sql: str) -> List[Dict[str, Any]]:
-        """Выполнение SQL запроса с ограничениями безопасности"""
+    async def execute_query(self, sql: str) -> Tuple[List[Dict[str, Any]], str]:
+        """Выполнение SQL запроса с ограничениями безопасности
+
+        Возвращает результаты выполнения и фактический SQL после нормализации.
+        """
 
         # Предварительная нормализация запроса
         sql = self._normalize_query(sql)
@@ -72,7 +75,7 @@ class DatabaseManager:
                 result = await connection.fetch(sql)
                 duration = time.perf_counter() - start_time
                 logger.info("SQL execution took %.3f seconds", duration)
-                return [dict(row) for row in result]
+                return [dict(row) for row in result], sql
                 
         except Exception as e:
             logger.error(f"Ошибка выполнения SQL: {e}")

--- a/main.py
+++ b/main.py
@@ -134,7 +134,9 @@ async def process_query(request: QueryRequest):
             last_sql = sgr_result.sql_query
 
             try:
-                query_results = await db_manager.execute_query(sgr_result.sql_query)
+                query_results, executed_sql = await db_manager.execute_query(
+                    sgr_result.sql_query
+                )
             except ValueError as e:
                 error_message = str(e)
                 logger.warning("SQL execution failed: %s", error_message)
@@ -142,13 +144,13 @@ async def process_query(request: QueryRequest):
 
             execution_time = int((time.time() - start_time) * 1000)
             logger.info(
-                "Generated SQL: %s | Execution time: %d ms",
-                sgr_result.sql_query,
+                "Executed SQL: %s | Execution time: %d ms",
+                executed_sql,
                 execution_time,
             )
 
             return QueryResponse(
-                sql_query=sgr_result.sql_query,
+                sql_query=executed_sql,
                 explanation=sgr_result.explanation,
                 confidence=sgr_result.confidence_score,
                 results=query_results,


### PR DESCRIPTION
## Summary
- return the normalized SQL used during execution
- surface the executed query in logs and API responses

## Testing
- `python -m py_compile main.py database.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baae1597d4832197cbc1e99461c37b
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance SQL query visibility by returning and logging executed SQL in `database.py` and `main.py`.
> 
>   - **Behavior**:
>     - `execute_query` in `database.py` now returns a tuple with query results and the executed SQL.
>     - Logs executed SQL in `process_query` in `main.py`.
>     - API response in `process_query` now includes the executed SQL.
>   - **Type Annotations**:
>     - Change return type of `execute_query` to `Tuple[List[Dict[str, Any]], str]` in `database.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hxrz11%2Fsgr-test2&utm_source=github&utm_medium=referral)<sup> for e3b12a0c0b424bf303cbe3da347c140504d41e47. You can [customize](https://app.ellipsis.dev/hxrz11/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->